### PR TITLE
Explicitly add namespace in patch

### DIFF
--- a/manifests/image-patch.yaml
+++ b/manifests/image-patch.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: nginx-deployment
+  namespace: nginx
 spec:
   template:
     spec:


### PR DESCRIPTION
Fixes this problem when running kustomize outside of manifests folder: kustomize build manifests
Error: no matches for Id Deployment.v1.apps/nginx-deployment.[noNs]; failed to find unique target for patch Deployment.v1.apps/nginx-deployment.[noNs]